### PR TITLE
FNAF-114 히트파티클 생성되는 애니매트로닉스의 히트파티클을 사용하게 수정

### DIFF
--- a/Assets/Resources/Images/Materials/Map.mat
+++ b/Assets/Resources/Images/Materials/Map.mat
@@ -24,7 +24,8 @@ Material:
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - _SPECULAR_SETUP
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -117,17 +118,17 @@ Material:
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Smoothness: 0.648
+    - _Smoothness: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
-    - _WorkflowMode: 1
+    - _WorkflowMode: 0
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 0.7905393, g: 0.82576835, b: 0.8962264, a: 1}
-    - _Color: {r: 0.7905393, g: 0.82576835, b: 0.8962264, a: 1}
+    - _BaseColor: {r: 0.48905307, g: 0.5461612, b: 0.6603774, a: 1}
+    - _Color: {r: 0.48905307, g: 0.5461611, b: 0.6603774, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Resources/Materials/1001/Pre_FreddyFazbear_Body.mat
+++ b/Assets/Resources/Materials/1001/Pre_FreddyFazbear_Body.mat
@@ -53,11 +53,11 @@ Material:
     - _Alpha: 0
     - _DissolveScale: 40
     - _DissolveWidth: 0.02
-    - _Normal: 1
+    - _Normal: 2.5
     - _Occlusion: 0.5
     - _QueueControl: 0
     - _QueueOffset: 0
-    - _Smoothness: 1
+    - _Smoothness: 3.5
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _DissolveColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Resources/Materials/1002/Pre_Freddy FrostBear_Body.mat
+++ b/Assets/Resources/Materials/1002/Pre_Freddy FrostBear_Body.mat
@@ -82,12 +82,12 @@ Material:
     - _Alpha: 0
     - _DissolveScale: 40
     - _DissolveWidth: 0.02
-    - _Metallic: 0
-    - _Normal: 1
-    - _Occlusion: 0.5
+    - _Metallic: 1
+    - _Normal: 2
+    - _Occlusion: 1
     - _QueueControl: 0
     - _QueueOffset: 0
-    - _Smoothness: 0.5
+    - _Smoothness: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _DissolveColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Resources/Materials/1003/AR_Balloon Boy_Eyes.mat
+++ b/Assets/Resources/Materials/1003/AR_Balloon Boy_Eyes.mat
@@ -60,19 +60,11 @@ Material:
         m_Texture: {fileID: 2800000, guid: abcb16e7f1c0fb545ac8ee5fcd2f1ef2, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _MRAC:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _Normal_Map:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -122,10 +114,8 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
-    - _IsVisible: 1
+    - _IsVisible: 0
     - _Metallic: 1
-    - _Normal: 1
-    - _Occlusion: 0.5
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueControl: 0
@@ -142,13 +132,11 @@ Material:
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 0.023529412, b: 0, a: 1}
-    - _DissolveColor: {r: 1, g: 1, b: 1, a: 1}
     - _Emission: {r: 23.968628, g: 0, b: 0.19976981, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []
---- !u!114 &3919041327230600752
+--- !u!114 &428272736718850815
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Resources/Materials/1003/Pre_Balloon Boy_Body.mat
+++ b/Assets/Resources/Materials/1003/Pre_Balloon Boy_Body.mat
@@ -54,7 +54,7 @@ Material:
     - _DissolveScale: 40
     - _DissolveWidth: 0.02
     - _Normal: 1
-    - _Occlusion: 0.5
+    - _Occlusion: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _Smoothness: 3.5

--- a/Assets/Resources/Materials/Glitch Material.mat
+++ b/Assets/Resources/Materials/Glitch Material.mat
@@ -41,7 +41,7 @@ Material:
     - _Force: 0
     - _GlitchSpeed: 10
     - _GlitchStrength: 1
-    - _NoiseAmount: 0
+    - _NoiseAmount: 1000
     - _ScanLineStrength: 1
     m_Colors: []
   m_BuildTextureStacks: []

--- a/Assets/Scenes/ShowSelectAnimatronicsScene.unity
+++ b/Assets/Scenes/ShowSelectAnimatronicsScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -504,15 +504,6 @@ MonoBehaviour:
   - {fileID: 8300000, guid: f80512a9d8b71724c8954802f5c9f1ba, type: 3}
   - {fileID: 8300000, guid: 692c953ea96cecf47a46532a0c699a76, type: 3}
   audioSource: {fileID: 0}
-  hitParticles:
-  - {fileID: 898073925}
-  - {fileID: 898073924}
-  - {fileID: 898073923}
-  - {fileID: 898073922}
-  - {fileID: 898073921}
-  - {fileID: 898073920}
-  - {fileID: 898073919}
-  - {fileID: 898073918}
   missParticle:
   - {fileID: 1125342979}
   - {fileID: 1125342978}
@@ -538,8 +529,6 @@ MonoBehaviour:
   - FreddyGlimpse2
   - FreddyGlimpse3
   jumpscareObject: {fileID: 0}
-  bodyShader: {fileID: 2100000, guid: 6182c274086d9a1419d7812129fa7834, type: 2}
-  eyeShader: {fileID: 2100000, guid: 85dc20327361da240bf203ba67fc319b, type: 2}
   isJumpState: 0
   isHitElectronic: 0
   flashButton: {fileID: 1379687986}
@@ -990,124 +979,6 @@ RectTransform:
   m_AnchoredPosition: {x: 142, y: 252}
   m_SizeDelta: {x: 284, y: 504}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &308503673
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 308503674}
-  - component: {fileID: 308503676}
-  - component: {fileID: 308503675}
-  m_Layer: 0
-  m_Name: Directional Light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &308503674
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308503673}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.44750625, y: -0.3978603, z: -0.36116824, w: 0.71484464}
-  m_LocalPosition: {x: -0.0005211551, y: -0.00050185295, z: 0}
-  m_LocalScale: {x: 0.0019302039, y: 0.0019302038, z: 0.0019302039}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000507731}
-  m_LocalEulerAnglesHint: {x: -68, y: -40.96, z: -25.33}
---- !u!114 &308503675
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308503673}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_UsePipelineSettings: 1
-  m_AdditionalLightsShadowResolutionTier: 2
-  m_LightLayerMask: 1
-  m_RenderingLayers: 1
-  m_CustomShadowLayers: 0
-  m_ShadowLayerMask: 1
-  m_ShadowRenderingLayers: 1
-  m_LightCookieSize: {x: 1, y: 1}
-  m_LightCookieOffset: {x: 0, y: 0}
-  m_SoftShadowQuality: 0
---- !u!108 &308503676
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308503673}
-  m_Enabled: 1
-  serializedVersion: 10
-  m_Type: 1
-  m_Shape: 0
-  m_Color: {r: 0.8962264, g: 0.8962264, b: 0.8962264, a: 1}
-  m_Intensity: 1
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 2
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 2
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 6570
-  m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_UseViewFrustumForShadowCasterCull: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 64.2
 --- !u!1001 &331264285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2676,6 +2547,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 122275785656669929, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 135171239771589102, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_IsActive
@@ -2690,6 +2566,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_CastShadows
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 170952014901232997, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 389907816442926813, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 633108150473405937, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
@@ -2821,6 +2707,11 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1510527214617335181, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1523900768179413764, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_PropertySheet.m_Bool.m_Array.Array.size
@@ -2941,6 +2832,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
       value: 3.4998364
       objectReference: {fileID: 0}
+    - target: {fileID: 1566023173560681783, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1645122880642998555, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_Enabled
@@ -2950,12 +2846,27 @@ PrefabInstance:
         type: 3}
       propertyPath: m_CastShadows
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1725257005660859640, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1891990193205861699, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 2103246656119344857, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2109283383734219248, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 2596946457188891664, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_Enabled
@@ -2965,6 +2876,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_CastShadows
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2998286645964566212, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 3018764257086388435, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
@@ -2976,11 +2892,36 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3053864880374631787, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3491101427363104750, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_Controller
       value: 
       objectReference: {fileID: 9100000, guid: c349759c9118ff049a16114760a720c2, type: 2}
+    - target: {fileID: 3589081041682267768, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3702216004009011435, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722095068812450692, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3743915241121171677, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3756657016333418562, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_PropertySheet.m_Bool.m_Array.Array.size
@@ -3351,6 +3292,11 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
       value: 3.517561
       objectReference: {fileID: 0}
+    - target: {fileID: 3941497750716400884, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 4210362856716267132, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_Enabled
@@ -3365,6 +3311,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4432814206333125614, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4751046000447180554, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4811447586417289442, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953189506744106437, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 4993812525942766629, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
@@ -3391,6 +3357,26 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5535899443878081947, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5681941124923475282, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6138354692616630286, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6153706137355403901, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 6214208661622047087, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_Enabled
@@ -3400,6 +3386,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_CastShadows
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565075665820867555, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 6641831918748773830, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
@@ -3976,10 +3967,25 @@ PrefabInstance:
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
       value: 3.7581058
       objectReference: {fileID: 0}
+    - target: {fileID: 7513759121934673385, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7543584371662907783, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 7875054062138694516, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7884646427151824981, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 7998146489314940619, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
@@ -3991,16 +3997,42 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8127400760050742922, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 8178010418348523728, guid: 1b9584e4e049b8541807410f5153deaa,
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8385579481101335603, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811408817978629381, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8889949658136173397, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 9190772799792689577, guid: 1b9584e4e049b8541807410f5153deaa,
+        type: 3}
+      propertyPath: Target
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3491101427363104750, guid: 1b9584e4e049b8541807410f5153deaa, type: 3}
     m_RemovedGameObjects:
     - {fileID: 7534779309782057527, guid: 1b9584e4e049b8541807410f5153deaa, type: 3}
     - {fileID: 7698726104514946347, guid: 1b9584e4e049b8541807410f5153deaa, type: 3}
+    - {fileID: 7875054062138694516, guid: 1b9584e4e049b8541807410f5153deaa, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 7998146489314940619, guid: 1b9584e4e049b8541807410f5153deaa,
@@ -4019,54 +4051,6 @@ PrefabInstance:
 --- !u!1 &898073917 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7998146489314940619, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073918 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 3841099657326775479, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073919 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 3756657016333418562, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073920 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 7441430039142810633, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073921 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 3928941393640083522, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073922 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 6718511047832331787, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073923 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 1523900768179413764, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073924 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 633108150473405937, guid: 1b9584e4e049b8541807410f5153deaa,
-    type: 3}
-  m_PrefabInstance: {fileID: 898073916}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &898073925 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 6667842820891660729, guid: 1b9584e4e049b8541807410f5153deaa,
     type: 3}
   m_PrefabInstance: {fileID: 898073916}
   m_PrefabAsset: {fileID: 0}
@@ -4583,7 +4567,6 @@ Transform:
   m_LocalScale: {x: 518.08, y: 518.08, z: 518.08}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 308503674}
   - {fileID: 1353320266}
   - {fileID: 789427105}
   - {fileID: 920424086}
@@ -4792,7 +4775,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!108 &1075000275
 Light:
   m_ObjectHideFlags: 0

--- a/Assets/Scirpts/Animatronics/Animatronics.cs
+++ b/Assets/Scirpts/Animatronics/Animatronics.cs
@@ -41,7 +41,7 @@ public class Animatronics : MonoBehaviour
     public AudioClip[] audioClips;
     public AudioSource audioSource;
 
-    [SerializeField] public VisualEffect[] hitParticles;
+    private VisualEffect[] hitParticles;
 
     [SerializeField] public VisualEffect[] missParticle;
     [SerializeField] public VisualEffect[] succParticle;
@@ -101,9 +101,11 @@ public class Animatronics : MonoBehaviour
 
     void Start()
     {
-        skinnedMaterials = transform.GetChild(1).GetComponentInChildren<SkinnedMeshRenderer>().materials;
+        skinnedMaterials = transform.GetChild(0).GetComponentInChildren<SkinnedMeshRenderer>().materials;
         bodyShader = skinnedMaterials[0];
         eyeShader = skinnedMaterials[1];
+        Debug.Log($"{transform.GetChild(0).name}");
+        hitParticles = transform.GetChild(0).GetComponentsInChildren<VisualEffect>();
 
         ShaderAlpahValueInitalize();    
         isFinishCircleMove = false;
@@ -111,11 +113,6 @@ public class Animatronics : MonoBehaviour
         isJumpState = false;
         isHitElectronic = false;
         useGlitch = true;
-
-        foreach (var effect in hitParticles)
-        {
-            effect.transform.GetComponent<VisualEffect>();
-        }
 
         foreach (var effect in missParticle)
         {
@@ -293,11 +290,11 @@ public class Animatronics : MonoBehaviour
         {
             state = "uniqueFeintState";
         }
-        else if (ran > chanceToUniqueFeint && ran <= 60)
+        else if (ran > chanceToUniqueFeint && ran <= (100 - chanceToUniqueFeint)/ 2 + chanceToUniqueFeint)
         {
             state = "soundFeintState";
         }
-        else if (ran > 60)
+        else if (ran > (100 - chanceToUniqueFeint) / 2 + chanceToUniqueFeint)
         {
             state = "invisibleFeintState";
         }

--- a/Assets/Scirpts/Animatronics/State/AttackSuccessState.cs
+++ b/Assets/Scirpts/Animatronics/State/AttackSuccessState.cs
@@ -18,7 +18,7 @@ public class AttackSuccessState : IState
         animatronics.flashButton.interactable = false;
         animatronics.shockButton.interactable = false;
         animatronics.GameOverOverlay();
-        animatronics.transform.GetChild(1).gameObject.SetActive(false);
+        animatronics.transform.GetChild(0).gameObject.SetActive(false);
     }
 
     public void Update()

--- a/Assets/Scirpts/Animatronics/State/IdleState.cs
+++ b/Assets/Scirpts/Animatronics/State/IdleState.cs
@@ -32,7 +32,6 @@ public class IdleState : IState
             Debug.Log($"state´Â {state}");
             IState nextState = controller.StateMachine.GetState(state);
             controller.StateMachine.TransitionTo(nextState);
-            //controller.StateMachine.TransitionTo(controller.StateMachine.uniqueFeintState);
         }
         else
         {

--- a/Assets/Settings/URP-Performant.asset
+++ b/Assets/Settings/URP-Performant.asset
@@ -57,7 +57,7 @@ MonoBehaviour:
   m_SoftShadowsSupported: 1
   m_ConservativeEnclosingSphere: 0
   m_NumIterationsEnclosingSphere: 64
-  m_SoftShadowQuality: 2
+  m_SoftShadowQuality: 1
   m_AdditionalLightsCookieResolution: 4096
   m_AdditionalLightsCookieFormat: 4
   m_UseSRPBatcher: 1
@@ -104,8 +104,8 @@ MonoBehaviour:
   m_PrefilterDBufferMRT1: 1
   m_PrefilterDBufferMRT2: 1
   m_PrefilterDBufferMRT3: 1
-  m_PrefilterSoftShadowsQualityLow: 1
-  m_PrefilterSoftShadowsQualityMedium: 0
+  m_PrefilterSoftShadowsQualityLow: 0
+  m_PrefilterSoftShadowsQualityMedium: 1
   m_PrefilterSoftShadowsQualityHigh: 1
   m_PrefilterSoftShadows: 1
   m_PrefilterScreenCoord: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -283,7 +283,14 @@ PlayerSettings:
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  m_BuildTargetIcons: []
+  m_BuildTargetIcons:
+  - m_BuildTarget: 
+    m_Icons:
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: 23614d5203bb3ac47974b875e17175c7, type: 3}
+      m_Width: 128
+      m_Height: 128
+      m_Kind: 0
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:


### PR DESCRIPTION
기존 애니매트로닉스 밑의 히트파티클을 인스펙터창에 등록하여 사용했지만
현재는 애니매트로닉스 밑에 id에 맞는 애니매트로닉스를 자식으로 Instantiate하여서 기존의 파티클을 사용하지 못하게 되었다.
자식으로 생성된 애니매트로닉스의 파티클을 찾아서 사용하는 기능 추가